### PR TITLE
Fix mismatch types of argument

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -4,7 +4,7 @@
 #
 
 config EXAMPLES_GHIFP
-	bool "Gacrux Host I/F protocol test"
+	tristate "Gacrux Host I/F protocol test"
 	default y
 	---help---
 		Enable the Gacrux Host I/F protocol test
@@ -14,7 +14,6 @@ if EXAMPLES_GHIFP
 config EXAMPLES_GHIFP_PROGNAME
 	string "Program name"
 	default "ghifp"
-	depends on BUILD_KERNEL
 	---help---
 		This is the name of the program that will be use when the NSH ELF
 		program is installed.

--- a/gacrux_cmd.c
+++ b/gacrux_cmd.c
@@ -2,6 +2,9 @@
  * Included Files
  ****************************************************************************/
 
+#include <nuttx/config.h>
+#include <nuttx/arch.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
@@ -170,7 +173,7 @@ static int str_to_bin(char *str, uint32_t str_len,
 
   if (binbufflen < str_to_bin_len)
     {
-      printf("Buffer is too small. str:%d,bin:%d\n", str_len, binbufflen);
+      printf("Buffer is too small. str:%ld,bin:%ld\n", str_len, binbufflen);
       return -1;
     }
 
@@ -212,7 +215,7 @@ static int calc_file_sz(FAR const char *file_path)
   file_sz = lseek(fd, 0, SEEK_END); /* Calc file size. */
   if (0 < file_sz)
     {
-      printf("File size:%u\n", file_sz);
+      printf("File size:%lu\n", file_sz);
     }
 
   close(fd);
@@ -329,7 +332,7 @@ static int tx_fw_res_check(uint8_t *res, uint32_t res_len)
     }
   else
     {
-      printf("Unexpected res_len:%d\n", res_len);
+      printf("Unexpected res_len:%ld\n", res_len);
       ret = -EIO;
       goto errout;
     }
@@ -364,7 +367,7 @@ static int bin_input_res_check(uint8_t *res, uint32_t res_len)
     }
   else
     {
-      printf("Unexpected res_len:%d\n", res_len);
+      printf("Unexpected res_len:%ld\n", res_len);
       ret = -EIO;
       goto errout;
     }
@@ -414,7 +417,7 @@ static int execute_fw_res_check(uint8_t *res, uint32_t res_len)
     }
   else
     {
-      printf("Unexpected res_len:%d\n", res_len);
+      printf("Unexpected res_len:%ld\n", res_len);
       ret = -EIO;
       goto errout;
     }
@@ -470,7 +473,7 @@ static int uartconf_res_check(uint8_t *res, uint32_t res_len)
     }
   else
     {
-      printf("Unexpected res_len:%d\n", res_len);
+      printf("Unexpected res_len:%ld\n", res_len);
       ret = -EIO;
       goto errout;
     }
@@ -549,7 +552,7 @@ static int i2cconf_res_check(uint8_t *res, uint32_t res_len)
     }
   else
     {
-      printf("Unexpected res_len:%d\n", res_len);
+      printf("Unexpected res_len:%ld\n", res_len);
       ret = -EIO;
       goto errout;
     }
@@ -604,7 +607,7 @@ static int spiconf_res_check(uint8_t *res, uint32_t res_len)
     }
   else
     {
-      printf("Unexpected res_len:%d\n", res_len);
+      printf("Unexpected res_len:%ld\n", res_len);
       ret = -EIO;
       goto errout;
     }
@@ -852,7 +855,7 @@ int gacrux_cmd_tx_fw(const char *fw_path)
 
       if (ret != pkt_len)
         {
-          printf("File read error. len:%d expected len:%u\n", ret, pkt_len);
+          printf("File read error. len:%u expected len:%lu\n", ret, pkt_len);
           ret = -EIO;
           break;
         }
@@ -863,7 +866,7 @@ int gacrux_cmd_tx_fw(const char *fw_path)
 
       /* -- Create command -- */
 
-      printf("Packet(%d/%d) fw part size:%d\n", i+1, loop_num, pkt_len);
+      printf("Packet(%d/%d) fw part size:%ld\n", i+1, loop_num, pkt_len);
 
       ret = host->transaction(host, cmd, TXFW_CMD_SIZE(pkt_len),
                               g_recv_buff, RECV_BUFF_SZ, &res_len);
@@ -998,7 +1001,7 @@ int gacrux_cmd_uartconf(uint8_t baudrate, uint8_t flow_ctrl)
   res_len = host->read(host, g_recv_buff, RECV_BUFF_SZ);
   if (res_len < 0)
     {
-      printf("Read error:%d\n", res_len);
+      printf("Read error:%ld\n", res_len);
       ret = res_len;
       goto exit;
     }
@@ -1195,7 +1198,7 @@ int gacrux_cmd_spiconf(uint8_t dfs)
   res_len = host->read(host, g_recv_buff, RECV_BUFF_SZ);
   if (res_len < 0)
     {
-      printf("Read error:%d\n", res_len);
+      printf("Read error:%ld\n", res_len);
       ret = res_len;
       goto exit;
     }
@@ -1363,7 +1366,7 @@ int gacrux_cmd_debug_file_send(const char *path)
   ret = read(fd, cmd, file_sz);
   if (ret != file_sz)
     {
-      printf("File read error. len:%d expected len:%u\n", ret, file_sz);
+      printf("File read error. len:%d expected len:%lu\n", ret, file_sz);
       ret = -EIO;
       goto exit;
     }
@@ -1451,7 +1454,7 @@ int gacrux_cmd_debug_tx_fw(uint32_t virtual_file_sz, uint16_t div_sz,
   CHECKINIT();
 
   printf("Start program transfer for debug.\n");
-  printf("Virtual file size = %u\n"
+  printf("Virtual file size = %lu\n"
          "Division size     = %u\n"
          "Total packet type = %u\n"
          "Packet No type    = %u\n",
@@ -1553,7 +1556,7 @@ int gacrux_cmd_debug_tx_fw(uint32_t virtual_file_sz, uint16_t div_sz,
         calc_checksum(&cmd[GHIFP_OPR_OFFSET], TXFW_OPR_SIZE(pkt_len));
       /* -- Create command -- */
 
-      printf("Packet(%d/%d) fw part size:%d\n", i+1, total_pkt_num, pkt_len);
+      printf("Packet(%d/%d) fw part size:%ld\n", i+1, total_pkt_num, pkt_len);
 
       ret = host->transaction(host, cmd, TXFW_CMD_SIZE(pkt_len),
                               g_recv_buff, RECV_BUFF_SZ, &res_len);
@@ -1605,11 +1608,11 @@ int gacrux_cmd_bin_input(uint8_t input, const char *fw_path)
 
   CHECKINIT();
   char path[] = "/mnt/spif/";
-  strcat(path, fw_path);
-  if (!path)
+  if (!fw_path)
   {
     return -EINVAL;
-    }
+  }
+  strcat(path, fw_path);
 
   file_sz = calc_file_sz(path);
   if (file_sz < 0)
@@ -1662,10 +1665,10 @@ int gacrux_cmd_bin_input(uint8_t input, const char *fw_path)
       *(uint16_t *)&cmd[7] = i+1;
 
       ret = read(fd, &cmd[8], pkt_len);
-       printf("pkt_len:%d \n", pkt_len);
+      printf("pkt_len:%ld\n", pkt_len);
       if (ret != pkt_len)
         {
-          printf("File read error. len:%d expected len:%u\n", ret, pkt_len);
+          printf("File read error. len:%d expected len:%lu\n", ret, pkt_len);
           ret = -EIO;
           break;
         }
@@ -1675,7 +1678,7 @@ int gacrux_cmd_bin_input(uint8_t input, const char *fw_path)
         calc_checksum(&cmd[GHIFP_OPR_OFFSET], TXFW_OPR_SIZE(pkt_len)-1);
       /* -- Create command -- */
 
-      printf("Packet(%d/%d) fw part size:%d\n", i+1, loop_num, pkt_len);
+      printf("Packet(%d/%d) fw part size:%ld\n", i+1, loop_num, pkt_len);
       ret = host->transaction(host, cmd + GHIFP_HEADER_SIZE, pkt_len + 4,
                           g_recv_buff, RECV_BUFF_SZ, &res_len);
       // ret = host->write(host, cmd + GHIFP_HEADER_SIZE,  pkt_len + 4);

--- a/ghifp_main.c
+++ b/ghifp_main.c
@@ -285,7 +285,7 @@ int ghifp_cmd_entry(int argc, FAR char *argv[])
           switch (gacrux_cmd_get_if_type())
           {
           case HOST_IF_FCTRY_TYPE_UART:
-            gacrux_cmd_debug_send(opr, (uint16_t)(argc - 2));
+            gacrux_cmd_debug_send((char *)opr, (uint16_t)(argc - 2));
             break;
           case HOST_IF_FCTRY_TYPE_I2C:
             ret = gacrux_cmd_i2cwrite((uint8_t)atoi(argv[1]), opr,

--- a/host_if_fctry.c
+++ b/host_if_fctry.c
@@ -35,7 +35,7 @@ static FAR struct host_if_s *g_host_list[HOST_IF_FCTRY_TYPE_NUM] = {0};
 
 int host_if_fctry_init(hostif_evt_cb evt_cb)
 {
-  int ret;
+  int ret = 0;
   printf("[IN]host_if_fctry_init %d\n", ret);
   ret = create_df_queue();
   if (ret < 0)

--- a/host_if_i2c.c
+++ b/host_if_i2c.c
@@ -87,7 +87,7 @@ static int i2c_recv_task(int argc, FAR char *argv[])
 
   memset(g_i2c_local_buf, 0, LOCAL_BUFF_SZ);
 
-  printf("I2C frequency(recv):%u\n", g_i2c_freq);
+  printf("I2C frequency(recv):%lu\n", g_i2c_freq);
 
   if (!g_dev)
     {
@@ -372,7 +372,7 @@ static int change_speed(uint8_t speed_number)
     }
   else
     {
-      printf("Change speed. %u -> %u\n", g_i2c_freq, (uint32_t)ret);
+      printf("Change speed. %lu -> %lu\n", g_i2c_freq, (uint32_t)ret);
       g_i2c_freq = (uint32_t)ret;
     }
 
@@ -425,7 +425,7 @@ static int host_if_i2c_write(
   uint8_t             opc;
   uint16_t            opr_len;
 
-  printf("host_if_i2c_write() len=%d\n", sz);
+  printf("host_if_i2c_write() len=%ld\n", sz);
 
   if (!thiz || !data || !sz)
     {
@@ -447,7 +447,7 @@ static int host_if_i2c_write(
       return ret;
     }
 
-  printf("I2C frequency:%u\n", g_i2c_freq);
+  printf("I2C frequency:%lu\n", g_i2c_freq);
 
   config.frequency = g_i2c_freq;
   config.address   = g_targetaddr;
@@ -474,7 +474,7 @@ static int host_if_i2c_read(
   int      ret = -EINVAL;
   uint32_t res_len;
 
-  printf("host_if_i2c_read() buflen=%d\n", sz);
+  printf("host_if_i2c_read() buflen=%ld\n", sz);
 
   if (!thiz || !buf || !sz)
     {
@@ -490,7 +490,7 @@ static int host_if_i2c_read(
     }
   else
     {
-      printf("Response dataframe len:%d\n", res_len);
+      printf("Response dataframe len:%ld\n", res_len);
       return res_len;
     }
 }
@@ -507,7 +507,7 @@ static int host_if_i2c_transaction(
   uint8_t             opc;
   uint16_t            opr_len;
 
-  printf("I2C transaction. write len=%d, read len=%d\n", w_sz, r_sz);
+  printf("I2C transaction. write len=%ld, read len=%ld\n", w_sz, r_sz);
 
   if (!thiz || !data || !w_sz || !buf || !r_sz || !res_len)
     {
@@ -529,7 +529,7 @@ static int host_if_i2c_transaction(
       return ret;
     }
 
-  printf("I2C frequency:%u\n", g_i2c_freq);
+  printf("I2C frequency:%lu\n", g_i2c_freq);
 
   config.frequency = g_i2c_freq;
   config.address   = g_targetaddr;
@@ -554,7 +554,7 @@ static int host_if_i2c_transaction(
     }
   else
     {
-      printf("Response dataframe len:%d\n", df_len);
+      printf("Response dataframe len:%ld\n", df_len);
       *res_len = df_len;
     }
 
@@ -569,7 +569,7 @@ static int host_if_i2c_dbg_write(
   int                 ret = -EINVAL;
   struct i2c_config_s config;
 
-  printf("host_if_i2c_dbg_write() len=%d\n", sz);
+  printf("host_if_i2c_dbg_write() len=%ld\n", sz);
 
   if (!thiz || !data || !sz)
     {
@@ -581,7 +581,7 @@ static int host_if_i2c_dbg_write(
       return -EPERM;
     }
 
-  printf("I2C frequency:%u\n", g_i2c_freq);
+  printf("I2C frequency:%lu\n", g_i2c_freq);
 
   config.frequency = g_i2c_freq;
   config.address   = g_targetaddr;

--- a/host_if_spi.c
+++ b/host_if_spi.c
@@ -2,6 +2,9 @@
  * Included Files
  ****************************************************************************/
 
+#include <nuttx/config.h>
+#include <nuttx/arch.h>
+
 #include <sdk/config.h>
 
 #include <stdio.h>
@@ -95,12 +98,11 @@ static int spi_recv_task(int argc, FAR char *argv[])
   int         ret;
   int         i;
   int         read_len;
-  int         read_len_tmp;
-  uint8_t     opc;
+  uint8_t     opc = 0;
   uint16_t    opr_len;
   int         finished_size = 0;
   memset(g_spi_local_buf, 0, LOCAL_BUFF_SZ);
-  printf("SPI frequency(recv):%u\n", g_spi_freq);
+  printf("SPI frequency(recv):%lu\n", g_spi_freq);
 
   if (!g_dev)
     {
@@ -516,7 +518,7 @@ static int set_clock(int clk_no)
   new_clock = conv_spi_clk_number(clk_no);
   if (0 < new_clock)
     {
-      printf("Change SPI frequency. %u -> %d\n", g_spi_freq, new_clock);
+      printf("Change SPI frequency. %lu -> %ld\n", g_spi_freq, new_clock);
       g_spi_freq = (uint32_t)new_clock;
       SPI_LOCK(g_dev, true);
       SPI_SETFREQUENCY(g_dev, g_spi_freq);
@@ -576,7 +578,7 @@ static int host_if_spi_read(
   int      ret = -EINVAL;
   uint32_t res_len;
 
-  printf("host_if_spi_read() buflen=%d\n", sz);
+  printf("host_if_spi_read() buflen=%ld\n", sz);
 
   if (!thiz || !buf || !sz)
     {
@@ -592,7 +594,7 @@ static int host_if_spi_read(
     }
   else
     {
-      printf("Response dataframe len:%d\n", res_len);
+      printf("Response dataframe len:%ld\n", res_len);
       return res_len;
     }
 }
@@ -605,10 +607,10 @@ static int host_if_spi_transaction(
 {
   int      ret = -EINVAL;
   uint32_t df_len;
-  uint8_t  opc;
-  uint16_t opr_len;
+//  uint8_t  opc;
+//  uint16_t opr_len;
 
-  printf("SPI transaction. write len=%d, read len=%d\n", w_sz, r_sz);
+  printf("SPI transaction. write len=%ld, read len=%ld\n", w_sz, r_sz);
 
   if (!thiz || !data || !w_sz || !buf || !r_sz || !res_len)
     {
@@ -645,7 +647,7 @@ static int host_if_spi_transaction(
     }
   else
     {
-      printf("Response dataframe len:%d\n", df_len);
+      printf("Response dataframe len:%ld\n", df_len);
       *res_len = df_len;
     }
 
@@ -659,7 +661,7 @@ static int host_if_spi_dbg_write(
 {
   int ret = -EINVAL;
 
-  printf("host_if_spi_dbg_write() len=%d\n", sz);
+  printf("host_if_spi_dbg_write() len=%ld\n", sz);
 
   if (!thiz || !data || !sz)
     {

--- a/host_if_uart.c
+++ b/host_if_uart.c
@@ -35,7 +35,7 @@ static int uart_recv_task(int argc, FAR char *argv[]);
 static int conv_uart_speed_number(uint8_t speed_no);
 static int set_baudrate(int fd, speed_t baudrate);
 static int change_baudrate(uint8_t speed_number);
-static int uart_open(const char *devpath, uint32_t baudrate);
+static int uart_open(const char *devpath, speed_t baudrate);
 static int uart_close(int fd);
 static int host_if_uart_write(
   FAR struct host_if_s *thiz, FAR uint8_t *data, uint32_t sz);
@@ -167,7 +167,7 @@ static int uart_recv_task(int argc, FAR char *argv[])
                   continue;
                 }
 
-              printf("Received dataframe completely. total_sz:%u\n",
+              printf("Received dataframe completely. total_sz:%lu\n",
                      total_sz);
 
               /* Completed to receive dataframe. */
@@ -374,7 +374,7 @@ static int host_if_uart_write(
   uint16_t opr_len;
   uint32_t total_sz = 0;
 
-  printf("host_if_uart_write() len=%d\n", sz);
+  printf("host_if_uart_write() len=%ld\n", sz);
 
   if (!thiz || !data || !sz)
     {
@@ -427,7 +427,7 @@ static int host_if_uart_read(
   int      ret = -EINVAL;
   uint32_t res_len;
 
-  printf("host_if_uart_read() buflen=%d\n", sz);
+  printf("host_if_uart_read() buflen=%ld\n", sz);
 
   if (!thiz || !buf || !sz)
     {
@@ -443,7 +443,7 @@ static int host_if_uart_read(
     }
   else
     {
-      printf("Response dataframe len:%d\n", res_len);
+      printf("Response dataframe len:%ld\n", res_len);
       return res_len;
     }
 }
@@ -461,7 +461,7 @@ static int host_if_uart_transaction(
   uint16_t opr_len;
   uint32_t total_sz = 0;
 
-  printf("UART transaction. write len=%d, read len=%d\n", w_sz, r_sz);
+  printf("UART transaction. write len=%ld, read len=%ld\n", w_sz, r_sz);
 
   if (!thiz || !data || !w_sz || !buf || !r_sz || !res_len)
     {
@@ -505,7 +505,7 @@ static int host_if_uart_transaction(
     }
   else
     {
-      printf("Response dataframe len:%d\n", df_len);
+      printf("Response dataframe len:%ld\n", df_len);
       *res_len = df_len;
     }
 
@@ -522,7 +522,7 @@ static int host_if_uart_dbg_write(
   int      fd;
   uint32_t total_sz = 0;
 
-  printf("host_if_uart_dbg_write() len=%d\n", sz);
+  printf("host_if_uart_dbg_write() len=%ld\n", sz);
 
   if (!thiz || !data || !sz)
     {


### PR DESCRIPTION
@KaidiNie 
spresense最新環境でghifpをコンパイルすると、uart_openの未定義エラーでビルドが失敗しました。
プロトタイプ宣言の引数型と実定義の引数型が異なっているためのようです。（C++のように引数型が異なると異なる関数として認識されると推測）

uart_openと他のワーニングを修正しましたのでPRしておきます。

```bash
$ arm-none-eabi-gcc.exe
 (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
```